### PR TITLE
視線推定時のエラーハンドリング追加

### DIFF
--- a/front-end/nuxt-app/pages/room/_id.vue
+++ b/front-end/nuxt-app/pages/room/_id.vue
@@ -151,6 +151,10 @@ export default {
       .showVideo(false)
       .showPredictionPoints(true)
       .setGazeListener((gaze, clock) => {
+        if (gaze == null) {
+          return;
+        }
+
         const x = gaze.x;
         const y = gaze.y;
 

--- a/front-end/nuxt-app/pages/room/_id.vue
+++ b/front-end/nuxt-app/pages/room/_id.vue
@@ -160,7 +160,7 @@ export default {
 
         const elementUnderGaze = document.elementFromPoint(x, y);
 
-        if (elementUnderGaze.tagName == null) {
+        if (elementUnderGaze === null) {
           return;
         }
 

--- a/front-end/nuxt-app/pages/room/_id.vue
+++ b/front-end/nuxt-app/pages/room/_id.vue
@@ -158,10 +158,14 @@ export default {
         const x = gaze.x;
         const y = gaze.y;
 
-        const elementUnderMouse = document.elementFromPoint(x, y);
+        const elementUnderGaze = document.elementFromPoint(x, y);
 
-        if (elementUnderMouse.tagName == 'VIDEO') {
-          this.focusThisVideo(elementUnderMouse.id);
+        if (elementUnderGaze.tagName == null) {
+          return;
+        }
+
+        if (elementUnderGaze.tagName == 'VIDEO') {
+          this.focusThisVideo(elementUnderGaze.id);
         }
       })
       .begin();


### PR DESCRIPTION
## 概要

視線推定時にエラーハンドリングを行う

・エラー箇所、内容
gazeとelementUnderGazeがnullの時

```
_id.vue?21cd:163 Uncaught (in promise) TypeError: Cannot read properties of null (reading 'tagName')
```